### PR TITLE
Fix `null` Not Being Allowed In Responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "pino": "8.0.0",
     "pino-pretty": "8.0.0",
     "sqlite3": "5.0.8",
-    "ts-json-validator": "0.7.1",
     "tsx": "3.4.3",
     "type-fest": "2.13.1",
     "typescript": "4.7.4",
@@ -51,7 +50,9 @@
   "devDependencies": {
     "@beequeue/eslint-plugin": "0.6.0",
     "@tsconfig/node16-strictest": "1.0.2",
+    "@types/json-schema": "7.0.11",
     "@types/node": "18.0.0",
+    "ajv": "8.11.0",
     "c8": "7.11.3",
     "dotenv": "16.0.1",
     "eslint": "8.18.0",

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -10,7 +10,6 @@ Sentry.init({
   enabled: NODE_ENV === "production",
   environment: NODE_ENV!,
   release: RENDER_GIT_COMMIT!,
-  debug: true,
   ignoreErrors: [/unsupported media type/i],
 })
 

--- a/src/routes/ids.test.ts
+++ b/src/routes/ids.test.ts
@@ -65,6 +65,8 @@ describe("query params", () => {
     const relation: Relation = {
       anidb: 1337,
       anilist: 1337,
+      myanimelist: null as any,
+      kitsu: null as any,
     }
     await knex.insert(relation).into("relations")
 
@@ -127,6 +129,24 @@ describe("json body", () => {
       const response = await app.inject().post("/api/ids").body({ anidb: 100_000 })
 
       expect(response.json()).toBe(null)
+      expect(response.statusCode).toBe(200)
+      expect(response.headers["content-type"]).toContain("application/json")
+    })
+
+    test("can return a partial response", async () => {
+      const relation: Relation = {
+        anidb: 1337,
+        anilist: 1337,
+        myanimelist: null as any,
+        kitsu: null as any,
+      }
+      await knex.insert(relation).into("relations")
+
+      const response = await app.inject().post("/api/ids").body({
+        anilist: 1337,
+      })
+
+      expect(response.json()).toStrictEqual(relation)
       expect(response.statusCode).toBe(200)
       expect(response.headers["content-type"]).toContain("application/json")
     })

--- a/src/routes/ids.test.ts
+++ b/src/routes/ids.test.ts
@@ -60,6 +60,23 @@ describe("query params", () => {
     expect(response.statusCode).toBe(200)
     expect(response.headers["content-type"]).toContain("application/json")
   })
+
+  test("can return a partial response", async () => {
+    const relation: Relation = {
+      anidb: 1337,
+      anilist: 1337,
+    }
+    await knex.insert(relation).into("relations")
+
+    const response = await app.inject().get("/api/ids").query({
+      source: Source.AniList,
+      id: relation.anilist,
+    })
+
+    expect(response.json()).toStrictEqual(relation)
+    expect(response.statusCode).toBe(200)
+    expect(response.headers["content-type"]).toContain("application/json")
+  })
 })
 
 describe("json body", () => {

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -1,6 +1,4 @@
-import { createSchema as S } from "ts-json-validator"
-
-import { enumToArray } from "@/utils"
+import { JSONSchema7 } from "json-schema"
 
 export enum Source {
   AniList = "anilist",
@@ -9,13 +7,13 @@ export enum Source {
   Kitsu = "kitsu",
 }
 
-export const sourceSchema = S({
+export const sourceSchema: JSONSchema7 = {
   type: "string",
-  enum: enumToArray(Source),
-})
+  enum: Object.values(Source),
+}
 
-export const idSchema = S({
+export const idSchema: JSONSchema7 = {
   type: "integer",
   minimum: 0,
   maximum: 50_000_000,
-})
+}

--- a/src/schemas/json-body.test.ts
+++ b/src/schemas/json-body.test.ts
@@ -1,4 +1,4 @@
-import { TsjsonParser } from "ts-json-validator"
+import Ajv, { Schema } from "ajv"
 import { JsonValue } from "type-fest"
 import { describe, expect, test } from "vitest"
 
@@ -36,12 +36,13 @@ describe("schema", () => {
     ...mapToSingularArrayInput(badCases),
   ]
 
-  const parser = new TsjsonParser(bodyInputSchema)
+  const ajv = new Ajv()
+  const validate = ajv.compile(bodyInputSchema as Schema)
 
   test.each(inputs)("%s = %p", (input, expected) => {
-    parser.validates(input)
+    validate(input)
 
-    const errors = parser.getErrors()
+    const { errors } = validate
     if (expected) {
       expect(errors).toBeNull()
     } else {

--- a/src/schemas/json-body.ts
+++ b/src/schemas/json-body.ts
@@ -1,4 +1,4 @@
-import { createSchema as S } from "ts-json-validator"
+import { JSONSchema7 } from "json-schema"
 
 import { knex, Relation } from "@/db"
 import { idSchema, Source, sourceSchema } from "@/schemas/common"
@@ -7,26 +7,26 @@ type BodyItem = {
   [key in Source]?: number
 }
 
-export const singularItemInputSchema = S({
+export const singularItemInputSchema: JSONSchema7 = {
   type: "object",
   propertyNames: sourceSchema,
   minProperties: 1,
   maxProperties: 4,
   additionalProperties: idSchema,
-})
+}
 
 export type BodyQuery = BodyItem | BodyItem[]
 
-const arrayInputSchema = S({
+const arrayInputSchema: JSONSchema7 = {
   type: "array",
   minItems: 1,
   maxItems: 100,
   items: singularItemInputSchema,
-})
+}
 
-export const bodyInputSchema = S({
+export const bodyInputSchema: JSONSchema7 = {
   oneOf: [singularItemInputSchema, arrayInputSchema],
-})
+}
 
 export const bodyHandler = async (
   input: BodyQuery,

--- a/src/schemas/query-params.test.ts
+++ b/src/schemas/query-params.test.ts
@@ -1,4 +1,4 @@
-import { TsjsonParser } from "ts-json-validator"
+import Ajv, { Schema } from "ajv"
 import { JsonValue } from "type-fest"
 import { describe, expect, test } from "vitest"
 
@@ -28,12 +28,13 @@ const badCases: Cases = [
 describe("schema", () => {
   const inputs: Cases = [...okCases, ...badCases]
 
-  const parser = new TsjsonParser(queryInputSchema)
+  const ajv = new Ajv()
+  const validate = ajv.compile(queryInputSchema as Schema)
 
   test.each(inputs)("%s = %p", (input, expected) => {
-    parser.validates(input)
+    validate(input)
 
-    const errors = parser.getErrors()
+    const { errors } = validate
     if (expected) {
       expect(errors).toBeNull()
     } else {

--- a/src/schemas/query-params.ts
+++ b/src/schemas/query-params.ts
@@ -1,4 +1,4 @@
-import { createSchema as S } from "ts-json-validator"
+import { JSONSchema7 } from "json-schema"
 
 import { knex } from "@/db"
 import { idSchema, Source, sourceSchema } from "@/schemas/common"
@@ -8,14 +8,14 @@ export type QueryParamQuery = {
   id: number
 }
 
-export const queryInputSchema = S({
+export const queryInputSchema: JSONSchema7 = {
   type: "object",
   properties: {
     source: sourceSchema,
     id: idSchema,
   },
   required: ["source", "id"],
-})
+}
 
 export const handleQueryParams = async (input: QueryParamQuery) => {
   return knex

--- a/src/schemas/response.ts
+++ b/src/schemas/response.ts
@@ -1,22 +1,31 @@
-import { createSchema as S } from "ts-json-validator"
+import { JSONSchema7 } from "json-schema"
 
-import { idSchema, sourceSchema } from "@/schemas/common"
+import { idSchema } from "@/schemas/common"
 
-const nullSchema = S({ type: "null" })
+const nullSchema: JSONSchema7 = { type: "null" }
 
-const responseItemSchema = S({
+const nullableIdSchema = {
+  oneOf: [nullSchema, idSchema],
+}
+
+export const responseItemSchema: JSONSchema7 = {
   type: "object",
-  propertyNames: sourceSchema,
-  additionalProperties: idSchema,
-})
+  additionalProperties: false,
+  properties: {
+    anidb: nullableIdSchema,
+    anilist: nullableIdSchema,
+    myanimelist: nullableIdSchema,
+    kitsu: nullableIdSchema,
+  },
+}
 
-const responseArraySchema = S({
+const responseArraySchema: JSONSchema7 = {
   type: "array",
-  items: S({
+  items: {
     oneOf: [nullSchema, responseItemSchema],
-  }),
-})
+  },
+}
 
-export const responseBodySchema = S({
+export const responseBodySchema: JSONSchema7 = {
   oneOf: [nullSchema, responseItemSchema, responseArraySchema],
-})
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
-export const enumToArray = <E>(e: E): E[] => Object.values(e)
-
 export const isEmpty = <T extends Record<string, unknown> | Record<string, unknown>[]>(
   obj?: T | null | undefined,
 ): obj is T => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -399,6 +399,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/json-schema@npm:7.0.11":
+  version: 7.0.11
+  resolution: "@types/json-schema@npm:7.0.11"
+  checksum: 527bddfe62db9012fccd7627794bd4c71beb77601861055d87e3ee464f2217c85fca7a4b56ae677478367bbd248dbde13553312b7d4dbc702a2f2bbf60c4018d
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.9":
   version: 7.0.9
   resolution: "@types/json-schema@npm:7.0.9"
@@ -620,19 +627,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.10.0, ajv@npm:^6.12.4, ajv@npm:^6.12.6":
-  version: 6.12.6
-  resolution: "ajv@npm:6.12.6"
-  dependencies:
-    fast-deep-equal: ^3.1.1
-    fast-json-stable-stringify: ^2.0.0
-    json-schema-traverse: ^0.4.1
-    uri-js: ^4.2.2
-  checksum: 874972efe5c4202ab0a68379481fbd3d1b5d0a7bd6d3cc21d40d3536ebff3352a2a1fabb632d4fd2cc7fe4cbdcd5ed6782084c9bbf7f32a1536d18f9da5007d4
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^8.0.0, ajv@npm:^8.1.0, ajv@npm:^8.10.0":
+"ajv@npm:8.11.0, ajv@npm:^8.0.0, ajv@npm:^8.1.0, ajv@npm:^8.10.0":
   version: 8.11.0
   resolution: "ajv@npm:8.11.0"
   dependencies:
@@ -641,6 +636,18 @@ __metadata:
     require-from-string: ^2.0.2
     uri-js: ^4.2.2
   checksum: 5e0ff226806763be73e93dd7805b634f6f5921e3e90ca04acdf8db81eed9d8d3f0d4c5f1213047f45ebbf8047ffe0c840fa1ef2ec42c3a644899f69aa72b5bef
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^6.10.0, ajv@npm:^6.12.4":
+  version: 6.12.6
+  resolution: "ajv@npm:6.12.6"
+  dependencies:
+    fast-deep-equal: ^3.1.1
+    fast-json-stable-stringify: ^2.0.0
+    json-schema-traverse: ^0.4.1
+    uri-js: ^4.2.2
+  checksum: 874972efe5c4202ab0a68379481fbd3d1b5d0a7bd6d3cc21d40d3536ebff3352a2a1fabb632d4fd2cc7fe4cbdcd5ed6782084c9bbf7f32a1536d18f9da5007d4
   languageName: node
   linkType: hard
 
@@ -795,7 +802,9 @@ __metadata:
     "@fastify/helmet": 9.1.0
     "@sentry/node": 7.2.0
     "@tsconfig/node16-strictest": 1.0.2
+    "@types/json-schema": 7.0.11
     "@types/node": 18.0.0
+    ajv: 8.11.0
     c8: 7.11.3
     cross-env: 7.0.3
     dotenv: 16.0.1
@@ -811,7 +820,6 @@ __metadata:
     prettier: 2.7.1
     sqlite3: 5.0.8
     sucrase: 3.21.0
-    ts-json-validator: 0.7.1
     tsconfig-paths: 4.0.0
     tsx: 3.4.3
     type-fest: 2.13.1
@@ -5525,17 +5533,6 @@ resolve@^2.0.0-next.3:
   version: 0.1.13
   resolution: "ts-interface-checker@npm:0.1.13"
   checksum: 20c29189c2dd6067a8775e07823ddf8d59a33e2ffc47a1bd59a5cb28bb0121a2969a816d5e77eda2ed85b18171aa5d1c4005a6b88ae8499ec7cc49f78571cb5e
-  languageName: node
-  linkType: hard
-
-"ts-json-validator@npm:0.7.1":
-  version: 0.7.1
-  resolution: "ts-json-validator@npm:0.7.1"
-  dependencies:
-    ajv: ^6.12.6
-  peerDependencies:
-    typescript: ">= 3.7.0"
-  checksum: cbcf06c792fd0397137660a1d8803ff050afb9e4e6f6a777d890ec2ce5d657184e37943f75b3ecc5c82cfa4d9c373b6ab285c727f5ff4eab7fbcfaad8967b59c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It seems AJV 8 does not allow `property: null` even if the property is not required, it either has to be the correct type or not exist at all.

Also removed `ts-json-validator` dependency to just use AJV directly