### PR TITLE
Switch to minified anime-list JSON

### DIFF
--- a/src/update.test.ts
+++ b/src/update.test.ts
@@ -24,7 +24,7 @@ afterAll(async () => {
 })
 
 it("handles bad values", async () => {
-	server.get("/Fribb/anime-lists/master/anime-list-full.json", {
+	server.get("/Fribb/anime-lists/master/anime-list-mini.json", {
 		status: 200,
 		body: [
 			{ anidb_id: 1337, themoviedb_id: "unknown" },
@@ -82,7 +82,7 @@ it("handles duplicates", async () => {
 	mocker.unmockGlobal()
 
 	const entries: Relation[] = await fetch(
-		"https://raw.githubusercontent.com/Fribb/anime-lists/master/anime-list-full.json",
+		"https://raw.githubusercontent.com/Fribb/anime-lists/master/anime-list-mini.json",
 	)
 		.then(async (r) => r.json())
 		.then((e) => (e as any[]).map(formatEntry))

--- a/src/update.ts
+++ b/src/update.ts
@@ -28,7 +28,7 @@ export type AnimeListsSchema = Array<{
 const fetchDatabase = async (): Promise<AnimeListsSchema | null> => {
 	const response = await http
 		.get<AnimeListsSchema>(
-			"https://raw.githubusercontent.com/Fribb/anime-lists/master/anime-list-full.json",
+			"https://raw.githubusercontent.com/Fribb/anime-lists/master/anime-list-mini.json",
 		)
 		.catch((error: XiorError) => error)
 


### PR DESCRIPTION
Separating from and per request in #906

### What changed:
Switched the data source JSON for the minified (exact same structure, fields and values, just no pretty-print) version. Savings are minimal (about ~50kb) but no reason not to use it since the file is never written to be read by a human.
<img width="747" height="561" alt="image" src="https://github.com/user-attachments/assets/1a3374f9-4c3b-4529-9f24-bad3594a9dd9" />
