### PR TITLE
fix: handle object form of themoviedb_id from Fribb data

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -25,7 +25,7 @@ export type AnimeListsSchema = Array<{
 	animenewsnetwork_id?: number
 	animecountdown_id?: number
 	simkl_id?: number
-	themoviedb_id?: number | "unknown"
+	themoviedb_id?: number | "unknown" | { tv?: number; movie?: number }
 	tvdb_id?: number
 	season?: {
 		tvdb?: number
@@ -104,7 +104,11 @@ export const formatEntry = (entry: AnimeListsSchema[number]): Relation => ({
 	media: handleBadValues(entry.type),
 	myanimelist: handleBadValues(entry.mal_id),
 	simkl: handleBadValues(entry.simkl_id),
-	themoviedb: handleBadValues(entry.themoviedb_id),
+	themoviedb: handleBadValues(
+		typeof entry.themoviedb_id === "object" && entry.themoviedb_id !== null
+			? (entry.themoviedb_id.tv ?? entry.themoviedb_id.movie)
+			: entry.themoviedb_id,
+	),
 	"themoviedb-season": handleBadValues(entry.season?.tmdb),
 	thetvdb: handleBadValues(entry.tvdb_id),
 	"thetvdb-season": handleBadValues(entry.season?.tvdb),


### PR DESCRIPTION
## Summary

`Fribb/anime-lists` now ships `themoviedb_id` as an object (`{tv?: number, movie?: number}`) for entries that have a TMDB match — 8,381 of the current 42,142 entries. `formatEntry` still passes the value straight into `handleBadValues`, so the object reaches the SQLite bind step and crashes:

```
TypeError: Provided value cannot be bound to SQLite parameter 13.
```

The crash happens during the initial DB rebuild, so the container never reaches a serving state.

Fix: extract `themoviedb_id.tv ?? themoviedb_id.movie` when it's an object before handing it to `handleBadValues`. Type widened accordingly.

## Test plan

- [x] Built from this branch, container started successfully, DB populated with 42,142 entries, `/api/v2/ids?source=anidb&id=12665` returns `themoviedb: 73223`.